### PR TITLE
fix GLFW error on linux/macos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,8 +164,8 @@ final var configureRunTask = { JavaExec it, String type ->
             '--add-opens', "java.base/java.lang.invoke=$sshModule",
             '--add-exports', "java.base/sun.security.util=$sshModule",
             '--add-exports', 'jdk.naming.dns/com.sun.jndi.dns=java.naming',
-
-            '-Dmixin.debug.verbose=true', '-Dmixin.debug.export=true'
+            '-Dmixin.debug.verbose=true', '-Dmixin.debug.export=true',
+            '-XstartOnFirstThread'
     )
     it.group = 'minecraft'
 


### PR DESCRIPTION
This fixes a GLFW error on linux / macOS causing the client to crash. 

`java.lang.ExceptionInInitializerError
	at MC-BOOTSTRAP/org.lwjgl.glfw@3.3.1+7/org.lwjgl.glfw.GLFW.glfwInit(GLFW.java:1046)
	at TRANSFORMER/minecraft/com.mojang.blaze3d.platform.GLX._initGlfw(SourceFile:68)
	at TRANSFORMER/minecraft/com.mojang.blaze3d.systems.RenderSystem.initBackendSystem(SourceFile:826)
	at TRANSFORMER/minecraft/net.minecraft.client.Minecraft.<init>(SourceFile:480)
	at TRANSFORMER/minecraft/net.minecraft.client.main.Main.run(SourceFile:205)
	at TRANSFORMER/minecraft/net.minecraft.client.main.Main.main(SourceFile:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at MC-BOOTSTRAP/io.github.brassmc.brassloader.boot/io.github.brassmc.brassloader.boot.target.BaseLaunchTarget.lambda$launchService$0(BaseLaunchTarget.java:34)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.Launcher.run(Launcher.java:106)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.Launcher.main(Launcher.java:77)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23)
	at cpw.mods.bootstraplauncher@1.1.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:141)
Caused by: java.lang.IllegalStateException: GLFW may only be used on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. This check may be disabled with Configuration.GLFW_CHECK_THREAD0.
	at MC-BOOTSTRAP/org.lwjgl.glfw@3.3.1+7/org.lwjgl.glfw.EventLoop.<clinit>(EventLoop.java:30)
	... 19 more`