### PR TITLE
Create mods folder if no exists

### DIFF
--- a/src/boot/java/io/github/brassmc/brassloader/boot/discovery/ModDiscovery.java
+++ b/src/boot/java/io/github/brassmc/brassloader/boot/discovery/ModDiscovery.java
@@ -35,6 +35,10 @@ public class ModDiscovery implements ITransformationService {
         try {
             final List<SecureJar> mods = new ArrayList<>();
 
+            if(Files.notExists(MODS_FOLDER)) {
+                Files.createDirectories(MODS_FOLDER);
+            }
+
             Files.walkFileTree(MODS_FOLDER, Set.of(), 1, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -13,8 +13,10 @@ import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.repository.PackSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.injection.*;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -56,15 +58,8 @@ public class MinecraftMixin {
         packRepository.reload();
     }
 
-    @ModifyConstant(method = "createTitle", constant = @Constant(stringValue = "Minecraft"))
-    private String brass$modifyBaseTitle(String s) {
+    @ModifyConstant(method = "createTitle()Ljava/lang/String;", constant = @Constant(stringValue = "Minecraft"))
+    private String brass$changeWindowTitle(String s) {
         return "Minecraft Brass";
-    }
-
-    @Inject(at = @At("RETURN"), method = "createTitle()Ljava/lang/String;", cancellable = true)
-    public void brass$removeModdedSymbol(CallbackInfoReturnable<String> cir) {
-        String titleString = cir.getReturnValue();
-        titleString = titleString.replaceAll("\\*", "");
-        cir.setReturnValue(titleString);
     }
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 @Mixin(Minecraft.class)
-public abstract class MinecraftMixin {
+public class MinecraftMixin {
 
     @Overwrite
     private UserApiService createUserApiService(YggdrasilAuthenticationService service, GameConfig cfg) {

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -13,9 +13,7 @@ import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.repository.PackSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.nio.file.Path;
@@ -59,11 +57,15 @@ public class MinecraftMixin {
         packRepository.reload();
     }
 
+    @ModifyConstant(method = "createTitle", constant = @Constant(stringValue = "Minecraft"))
+    private String brass$modifyBaseTitle(String s) {
+        return "Minecraft Brass";
+    }
+
     @Inject(at = @At("RETURN"), method = "createTitle()Ljava/lang/String;", cancellable = true)
-    public void brass$changeWindowTitle(CallbackInfoReturnable<String> cir) {
-        String title = cir.getReturnValue();
-        title = title.replaceAll("Minecraft", "Brass MC");
-        title = title.replaceAll("\\*", "");
-        cir.setReturnValue(title);
+    public void brass$removeModdedSymbol(CallbackInfoReturnable<String> cir) {
+        String titleString = cir.getReturnValue();
+        titleString = titleString.replaceAll("\\*", "");
+        cir.setReturnValue(titleString);
     }
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -61,6 +61,6 @@ public abstract class MinecraftMixin {
 
     @Inject(method = "createTitle", at = @At("HEAD"), cancellable = true)
     private void brassloader$changeWindowTitle(CallbackInfoReturnable<String> ci) {
-        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName() + (server != null && server.isRemote()) ? "Multiplayer" : "Singleplayer");
+        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName() + " " + (server != null && server.isRemote()) ? "Multiplayer" : "Singleplayer");
     } 
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -14,7 +14,9 @@ import net.minecraft.server.packs.repository.PackSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,8 +25,6 @@ import java.util.Set;
 
 @Mixin(Minecraft.class)
 public abstract class MinecraftMixin {
-    @Shadow
-    private IntegratedServer server;
 
     @Overwrite
     private UserApiService createUserApiService(YggdrasilAuthenticationService service, GameConfig cfg) {
@@ -59,8 +59,11 @@ public abstract class MinecraftMixin {
         packRepository.reload();
     }
 
-    @Inject(method = "createTitle", at = @At("HEAD"), cancellable = true)
-    private void brassloader$changeWindowTitle(CallbackInfoReturnable<String> ci) {
-        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName() + " " + (server != null && server.isRemote()) ? "Multiplayer" : "Singleplayer");
-    } 
+    @Inject(at = @At("RETURN"), method = "createTitle()Ljava/lang/String;", cancellable = true)
+    public void brass$changeWindowTitle(CallbackInfoReturnable<String> cir) {
+        String title = cir.getReturnValue();
+        title = title.replaceAll("Minecraft", "Brass MC");
+        title = title.replaceAll("\\*", "");
+        cir.setReturnValue(title);
+    }
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -23,6 +23,8 @@ import java.util.Set;
 
 @Mixin(Minecraft.class)
 public abstract class MinecraftMixin {
+    @Shadow
+    private IntegratedServer server;
 
     @Overwrite
     private UserApiService createUserApiService(YggdrasilAuthenticationService service, GameConfig cfg) {
@@ -59,6 +61,6 @@ public abstract class MinecraftMixin {
 
     @Inject(method = "createTitle", at = @At("HEAD"), cancellable = true)
     private void brassloader$changeWindowTitle(CallbackInfoReturnable<String> ci) {
-        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName());
+        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName() + (server != null && server.isRemote()) ? "Multiplayer" : "Singleplayer");
     } 
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -22,7 +22,8 @@ import java.util.List;
 import java.util.Set;
 
 @Mixin(Minecraft.class)
-public class MinecraftMixin {
+public abstract class MinecraftMixin {
+
     @Overwrite
     private UserApiService createUserApiService(YggdrasilAuthenticationService service, GameConfig cfg) {
         return UserApiService.OFFLINE;
@@ -55,4 +56,9 @@ public class MinecraftMixin {
         access.setSources(Set.copyOf(sources));
         packRepository.reload();
     }
+
+    @Inject(method = "createTitle", at = @At("HEAD"), cancellable = true)
+    private void brassloader$changeWindowTitle(CallbackInfoReturnable<String> ci) {
+        ci.setReturnValue("Minecraft Brass" + SharedConstants.getCurrentVersion().getName());
+    } 
 }

--- a/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
+++ b/src/mixin/java/io/github/brassmc/brassloader/mixin/MinecraftMixin.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-
     @Overwrite
     private UserApiService createUserApiService(YggdrasilAuthenticationService service, GameConfig cfg) {
         return UserApiService.OFFLINE;


### PR DESCRIPTION
Prior to this PR a `java.nio.file.NoSuchFileException: mods` was thrown when no mods folder existed. By creating one if there is no, this is fixed.